### PR TITLE
Mpm app and tachikoma tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -42,3 +42,6 @@ branch = "tachikoma-rewrite"
 
 [targets]
 test = ["Test"]
+
+[apps]
+mpm = { submodule = "CLI" }

--- a/bin/mpm.jl
+++ b/bin/mpm.jl
@@ -1,108 +1,11 @@
 #!/usr/bin/env julia
 
-"""
-mpm - MultiProgressManager CLI
-
-Usage:
-  mpm <database_file.db>     View single experiment database
-  mpm <folder_path>          View folder of experiment databases
-  mpm .                      View ./progresslogs/ folder (if exists)
-  mpm --help                 Show this help message
-
-Examples:
-  mpm ./progresslogs/experiment1.db
-  mpm ./progresslogs/
-  mpm ~/.local/share/MultiProgressManagers/default.db
-"""
-
 using Pkg
 Pkg.activate(joinpath(@__DIR__, ".."))
 using MultiProgressManagers
-using Tachikoma
 
 function main()
-    args = ARGS
-
-    if isempty(args) || args[1] in ("-h", "--help", "help")
-        println("""
-            mpm - MultiProgressManager Dashboard
-
-            Usage:
-              mpm <database_file.db>     View single experiment database
-              mpm <folder_path>          View folder of experiment databases  
-              mpm .                      View ./progresslogs/ folder (if exists)
-              
-            Examples:
-              mpm ./progresslogs/experiment1.db
-              mpm ./progresslogs/
-              mpm ~/.local/share/MultiProgressManagers/default.db
-              
-            Keyboard Shortcuts (in dashboard):
-              [1-2]     Switch tabs (Runs, Details)
-              [↑↓]      Navigate lists
-              [Enter]   Select / Open
-              [q]       Quit
-            """)
-        return 0
-    end
-
-    path = args[1]
-
-    # Handle special case: mpm . -> look for ./progresslogs/
-    if path == "."
-        if isdir("./progresslogs")
-            path = "./progresslogs"
-        else
-            # Try to find default database
-            cache_dir = get(ENV, "XDG_DATA_HOME", joinpath(homedir(), ".local", "share"))
-            default_db = joinpath(cache_dir, "MultiProgressManagers", "default.db")
-            if isfile(default_db)
-                path = default_db
-            else
-                println("Error: No ./progresslogs/ directory found and no default database exists.")
-                println("Run an experiment first, or specify a database file path.")
-                return 1
-            end
-        end
-    end
-
-    # Determine if path is file or folder
-    if isfile(path)
-        # Single database mode
-        db_path = path
-    elseif isdir(path)
-        # Folder mode - find all .db files
-        db_files = filter(f -> endswith(f, ".db"), readdir(path; join=true))
-        if isempty(db_files)
-            println("Error: No .db files found in directory: $path")
-            return 1
-        end
-        db_path = first(db_files)
-        if length(db_files) > 1
-            println("Note: Multiple databases found, using: $(basename(db_path))")
-        end
-    else
-        println("Error: Path not found: $path")
-        return 1
-    end
-
-    # Launch dashboard
-    try
-        println("Loading dashboard for: $path")
-        println("Press 'q' to quit, '1-2' for tabs")
-
-        view_dashboard(db_path)
-
-        return 0
-    catch e
-        if e isa InterruptException
-            println("\nInterrupted.")
-            return 0
-        else
-            println("Error: $e")
-            return 1
-        end
-    end
+    return MultiProgressManagers.CLI.main(String.(ARGS))
 end
 
 exit(main())

--- a/src/MultiProgressManagers.jl
+++ b/src/MultiProgressManagers.jl
@@ -14,6 +14,7 @@ include("dashboard/view.jl")
 include("dashboard/update.jl")
 include("dashboard/runs_tab.jl")
 include("dashboard/running_tab.jl")
+include("cli.jl")
 
 # Re-export from Database
 export Database

--- a/src/channel.jl
+++ b/src/channel.jl
@@ -66,7 +66,7 @@ function _current_slot(channels::Vector{Any}, ::Val{:remote})
 end
 
 function _ensure_channels_vector!(::Nothing, manager::ProgressManager)
-    vec = [nothing, nothing]
+    vec = Any[nothing, nothing]
     manager._channels = vec
     return vec
 end

--- a/src/cli.jl
+++ b/src/cli.jl
@@ -1,0 +1,103 @@
+module CLI
+
+using ..MultiProgressManagers: view_dashboard
+
+function _help_text()
+    return """
+        mpm - MultiProgressManager Dashboard
+
+        Usage:
+          mpm <database_file.db>     View single experiment database
+          mpm <folder_path>          View folder of experiment databases
+          mpm .                      View ./progresslogs/ folder (if exists)
+          mpm --help                 Show this help message
+
+        Examples:
+          mpm ./progresslogs/experiment1.db
+          mpm ./progresslogs/
+          mpm ~/.local/share/MultiProgressManagers/default.db
+
+        Keyboard Shortcuts (in dashboard):
+          [1-2]     Switch tabs (Runs, Details)
+          [↑↓]      Navigate lists
+          [Enter]   Select / Open
+          [q]       Quit
+        """
+end
+
+function _default_dashboard_path()
+    if isdir("./progresslogs")
+        return "./progresslogs"
+    end
+    cache_dir = get(ENV, "XDG_DATA_HOME", joinpath(homedir(), ".local", "share"))
+    default_db = joinpath(cache_dir, "MultiProgressManagers", "default.db")
+    if isfile(default_db)
+        return default_db
+    end
+    return nothing
+end
+
+function _resolve_dashboard_path(path::String)
+    if path == "."
+        default_path = _default_dashboard_path()
+        if default_path === nothing
+            println("Error: No ./progresslogs/ directory found and no default database exists.")
+            println("Run an experiment first, or specify a database file path.")
+            return nothing
+        end
+        return default_path
+    end
+
+    if isfile(path)
+        return path
+    end
+
+    if isdir(path)
+        db_files = filter(f -> endswith(f, ".db"), readdir(path; join = true))
+        if isempty(db_files)
+            println("Error: No .db files found in directory: $path")
+            return nothing
+        end
+        return path
+    end
+
+    println("Error: Path not found: $path")
+    return nothing
+end
+
+function print_help(io::IO = stdout)
+    println(io, _help_text())
+    return nothing
+end
+
+function main(args::Vector{String} = String.(ARGS))
+    if isempty(args) || args[1] in ("-h", "--help", "help")
+        print_help()
+        return 0
+    end
+
+    resolved_path = _resolve_dashboard_path(args[1])
+    if resolved_path === nothing
+        return 1
+    end
+
+    try
+        println("Loading dashboard for: $resolved_path")
+        println("Press 'q' to quit, '1-2' for tabs")
+        view_dashboard(resolved_path)
+        return 0
+    catch err
+        if err isa InterruptException
+            println("\nInterrupted.")
+            return 0
+        end
+        println("Error: $err")
+        return 1
+    end
+end
+
+function (@main)(ARGS)
+    return main(String.(ARGS))
+end
+
+end

--- a/test/core.jl
+++ b/test/core.jl
@@ -5,6 +5,49 @@ using DataFrames
 using DBInterface
 
 const MPM = MultiProgressManagers
+const TK = MPM.Tachikoma
+
+function _wait_for_task_completion(
+    manager::MPM.ProgressManager;
+    timeout_seconds::Float64 = 10.0,
+)
+    deadline = time() + timeout_seconds
+    while time() < deadline
+        tasks = Database.get_experiment_tasks(manager.db_handle, manager.experiment_id)
+        all_done = nrow(tasks) == manager.total_tasks &&
+            all(row -> String(row.status) == "completed" && row.current_step == row.total_steps, eachrow(tasks))
+        if all_done
+            return tasks
+        end
+        sleep(0.01)
+    end
+    return Database.get_experiment_tasks(manager.db_handle, manager.experiment_id)
+end
+
+function _apply_script!(model::MPM.ProgressDashboard, script::TK.EventScript; fps::Int = 60)
+    for (_, event) in script(fps)
+        TK.update!(model, event)
+    end
+    return nothing
+end
+
+function _frame_for_backend(tb::TK.TestBackend)
+    return TK.Frame(
+        tb.buf,
+        TK.Rect(1, 1, tb.width, tb.height),
+        TK.GraphicsRegion[],
+        TK.PixelSnapshot[],
+    )
+end
+
+function _buffer_contains(tb::TK.TestBackend, text::String)
+    for y in 1:tb.height
+        if occursin(text, TK.row_text(tb, y))
+            return true
+        end
+    end
+    return false
+end
 
 @testset "Schema: tables and display_message column" begin
     test_db = tempname() * ".db"
@@ -34,6 +77,117 @@ end
         tasks = Database.get_experiment_tasks(manager.db_handle, manager.experiment_id)
         @test nrow(tasks) == 3
     finally
+        Database.close_db!(manager.db_handle)
+        rm(test_db, force = true)
+    end
+end
+
+@testset "Dashboard: mock inputs and headless rendering" begin
+    test_db = tempname() * ".db"
+    manager = MPM.create_experiment("DashMock", 3; db_path = test_db)
+    try
+        MPM.update!(manager, 1, 2; total_steps = 5, message = "epoch 2")
+        MPM.update!(manager, 2, 1; total_steps = 3, message = "warmup")
+
+        dashboard = MPM.ProgressDashboard(
+            db_path = test_db,
+            db_handle = manager.db_handle,
+            poll_frequency_ms = 0,
+        )
+        MPM._poll_database!(dashboard)
+
+        @test length(dashboard.admin_experiments) == 1
+        selected_id = ismissing(dashboard.admin_experiments[1].id) ? "" : dashboard.admin_experiments[1].id
+        @test !isempty(selected_id)
+
+        dashboard.runs_selected = 1
+        dashboard.selected_experiment_id = selected_id
+
+        script = TK.EventScript(
+            (0.0, TK.key('2')),
+            (0.0, TK.key(:tab)),
+            (0.0, TK.key(:down)),
+            (0.0, TK.key('1')),
+            (0.0, TK.key('f')),
+            (0.0, TK.key(:right)),
+            (0.0, TK.key(:enter)),
+        )
+        _apply_script!(dashboard, script)
+
+        @test dashboard.active_tab == 1
+        @test dashboard.running_focus == 2
+        @test dashboard.task_scroll_offset == 1
+        @test dashboard.confirm_mark_failed_id === nothing
+
+        experiment = Database.get_experiment(manager.db_handle, manager.experiment_id)
+        @test experiment !== nothing
+        @test String(experiment.status) == "failed"
+
+        dashboard.active_tab = 2
+        dashboard.running_focus = 1
+        dashboard.task_scroll_offset = 0
+        MPM._poll_database!(dashboard)
+        dashboard.runs_selected = 1
+        dashboard.selected_experiment_id = selected_id
+
+        backend = TK.TestBackend(130, 36)
+        frame = _frame_for_backend(backend)
+        TK.view(dashboard, frame)
+
+        @test _buffer_contains(backend, "Tasks for DashMock")
+        @test _buffer_contains(backend, "Message")
+        @test _buffer_contains(backend, "epoch 2")
+    finally
+        Database.close_db!(manager.db_handle)
+        rm(test_db, force = true)
+    end
+end
+
+@testset "Stress: rapid multithreaded ProgressTask updates" begin
+    test_db = tempname() * ".db"
+    total_tasks = max(4, min(16, Base.Threads.nthreads() * 4))
+    updates_per_task = 250
+    manager = MPM.create_experiment("StressTest", total_tasks; db_path = test_db)
+    local_tasks = [MPM.get_task(manager, task_number, :local) for task_number in 1:total_tasks]
+    try
+        Base.Threads.@threads for task_number in 1:total_tasks
+            task = local_tasks[task_number]
+            for step in 1:updates_per_task
+                MPM.report_progress!(
+                    task,
+                    step;
+                    total_steps = updates_per_task,
+                    message = "task $(task_number) step $(step)",
+                )
+            end
+            MPM.finish!(task)
+        end
+
+        completed_tasks = _wait_for_task_completion(manager; timeout_seconds = 15.0)
+        @test nrow(completed_tasks) == total_tasks
+        @test all(row -> String(row.status) == "completed", eachrow(completed_tasks))
+        @test all(row -> row.total_steps == updates_per_task, eachrow(completed_tasks))
+        @test all(row -> row.current_step == updates_per_task, eachrow(completed_tasks))
+        @test all(
+            row -> !ismissing(row.display_message) && occursin("step", String(row.display_message)),
+            eachrow(completed_tasks),
+        )
+
+        if manager._listener_task !== nothing
+            wait(manager._listener_task)
+        end
+
+        MPM.finish_experiment!(manager)
+        experiment = Database.get_experiment(manager.db_handle, manager.experiment_id)
+        @test experiment !== nothing
+        @test String(experiment.status) == "completed"
+    finally
+        if !isempty(local_tasks)
+            shared_channel = local_tasks[1].channel
+            if shared_channel isa Channel{MPM.ProgressMessage} && isopen(shared_channel)
+                close(shared_channel)
+            end
+        end
         Database.close_db!(manager.db_handle)
         rm(test_db, force = true)
     end


### PR DESCRIPTION
Integrates `mpm` as a Julia app for `~/.julia/bin` installation and adds robust Tachikoma-style mock-input and multithreaded stress tests, fixing a channel initialization bug.

The new multithreaded stress test exposed a bug where `_channels` was initialized as `Vector{Nothing}`, leading to crashes on the first `get_task` write; this is now fixed by explicitly setting it to `Vector{Any}`.

---
<p><a href="https://cursor.com/agents/bc-f774b34c-004a-4737-8c3e-c79039b07ecf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f774b34c-004a-4737-8c3e-c79039b07ecf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

