### PR TITLE
Don't error if log dir empty

### DIFF
--- a/src/cli.jl
+++ b/src/cli.jl
@@ -26,14 +26,6 @@ function _help_text()
     """
 end
 
-function _db_files_in_directory(path::String)
-    db_files = filter(readdir(path; join = true)) do entry
-        return endswith(lowercase(entry), ".db")
-    end
-    sort!(db_files)
-    return db_files
-end
-
 function _resolve_dashboard_path(path::String)
     if path == "."
         path = abspath(".")
@@ -44,11 +36,6 @@ function _resolve_dashboard_path(path::String)
     end
 
     if isdir(path)
-        db_files = _db_files_in_directory(path)
-        if isempty(db_files)
-            println("Error: No .db files found in directory: $path")
-            return nothing
-        end
         return path
     end
 

--- a/src/dashboard/model.jl
+++ b/src/dashboard/model.jl
@@ -362,7 +362,7 @@ end
 Launch a Tachikoma dashboard for viewing experiment progress.
 
 # Arguments
-- `db_path::String`: Path to experiment database file, or folder containing .db files
+- `db_path::String`: Path to experiment database file, or folder to watch for `.db` files (empty folders are allowed)
 - `poll_frequency_ms::Int=500`: How often to poll database for updates (lower = more frequent)
 - `speed_window_seconds::Real=30`: Time window for short-horizon speed calculation
 - `folder_discovery_interval_ms::Int=5000`: In folder mode, how often to re-scan for new .db files
@@ -381,12 +381,8 @@ function view_dashboard(db_path::String; poll_frequency_ms::Int=500, speed_windo
     folder_mode = isdir(db_path)
     
     if folder_mode
-        # Find all .db files in folder
+        # Find all .db files in folder (may be empty; new files are picked up on refresh)
         available_dbs = _discover_db_files(db_path)
-
-        if isempty(available_dbs)
-            error("No .db files found in folder: $db_path")
-        end
 
         active_tab = 1
     else

--- a/test/core.jl
+++ b/test/core.jl
@@ -327,6 +327,27 @@ end
     end
 end
 
+@testset "Empty log directory does not error" begin
+    folder = mktempdir()
+    try
+        @test MPM.CLI._resolve_dashboard_path(folder) == folder
+
+        dashboard = MPM.ProgressDashboard(
+            db_path = folder,
+            db_handles = Dict{String,Database.DBHandle}(),
+            folder_mode = true,
+            folder_path = folder,
+            available_dbs = String[],
+            poll_frequency_ms = 0,
+        )
+        MPM._poll_database!(dashboard)
+        @test isempty(dashboard.admin_experiments)
+        @test isempty(dashboard.running_experiments)
+    finally
+        rm(folder; force = true, recursive = true)
+    end
+end
+
 @testset "Stress: rapid multithreaded ProgressTask updates" begin
     test_db = tempname() * ".db"
     total_tasks = max(4, min(16, Base.Threads.nthreads() * 4))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Opening the dashboard on a progress-log **folder** with no `.db` files used to exit with an error from both the `mpm` CLI and `view_dashboard`. That is now allowed: the UI starts with an empty experiment list (same as "No experiments found" when databases exist but have no rows).

## Changes

- **`src/cli.jl`**: Resolve existing directories without requiring at least one `.db` file; removed unused `_db_files_in_directory`.
- **`src/dashboard/model.jl`**: Removed `error(...)` when folder discovery finds no databases; documented that empty folders are valid.
- **`test/core.jl`**: Test that `_resolve_dashboard_path` accepts an empty folder and `_poll_database!` yields empty admin/running lists.

## Testing

`Pkg.test()` — all 110 tests pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d9d60c5-c508-4299-820d-81975a68d205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d9d60c5-c508-4299-820d-81975a68d205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

