### PR TITLE
ci: remove deprecated TagBot workflow_dispatch lookback input

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -4,10 +4,6 @@ on:
     types:
       - created
   workflow_dispatch:
-    inputs:
-      lookback:
-        description: "[DEPRECATED] No longer has any effect"
-        default: "3"
 jobs:
   TagBot:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'


### PR DESCRIPTION
TagBot v1.23.0+ ignores lookback; upstream documents that it can be removed.