### PR TITLE
fix(dashboard): correct Started column time (Julia DateFormat mm vs MM)

### DIFF
--- a/src/dashboard/model.jl
+++ b/src/dashboard/model.jl
@@ -516,7 +516,7 @@ end
 function format_datetime(dt::Union{DateTime,Nothing})::String
     dt === nothing && return "Unknown"
     local_dt = instant_to_local_wall_datetime(dt)
-    return Dates.format(local_dt, dateformat"HH:mm:ss")
+    return Dates.format(local_dt, dateformat"HH:MM:SS")
 end
 
 """
@@ -527,7 +527,7 @@ function format_datetime_for_started_column(dt::Union{DateTime,Nothing}, include
     dt === nothing && return "Unknown"
     local_dt = instant_to_local_wall_datetime(dt)
     if include_date
-        return Dates.format(local_dt, dateformat"yyyy-mm-dd HH:mm")
+        return Dates.format(local_dt, dateformat"yyyy-mm-dd HH:MM")
     end
-    return Dates.format(local_dt, dateformat"HH:mm:ss")
+    return Dates.format(local_dt, dateformat"HH:MM:SS")
 end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

In the Runs tab, the "Started" column showed the **month** where **minutes** should appear (e.g. `03` in April), because `Dates.format` uses different token meanings than POSIX/strftime: `mm` is **month**, `MM` is **minute**.

## Change

Updated `format_datetime` and `format_datetime_for_started_column` in `src/dashboard/model.jl` to use `HH:MM:SS` and `yyyy-mm-dd HH:MM` instead of `HH:mm:ss` / `HH:mm`.

## Verification

`Pkg.test()` passes (126 tests).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d379064-b59e-4b6f-a274-643440c9da27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d379064-b59e-4b6f-a274-643440c9da27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

