### PR TITLE
fix(dashboard): correct experiment duration (UTC vs local now)

### DIFF
--- a/src/dashboard/model.jl
+++ b/src/dashboard/model.jl
@@ -498,7 +498,8 @@ function format_duration(::Nothing, _)::String
 end
 
 function format_duration(started_at::DateTime, finished_at::Union{DateTime,Nothing})::String
-    end_time = finished_at === nothing ? now() : finished_at
+    # DB times are UTC instants (`unix2datetime`); use the same basis for "now" — not `now()` (local wall clock).
+    end_time = finished_at === nothing ? unix2datetime(time()) : finished_at
     duration = end_time - started_at
     total_seconds = round(Int, Dates.value(duration) / 1000)
     


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Experiment durations in the dashboard could be wrong by the local UTC offset (e.g. **two hours too long** in UTC+2) because `format_duration` compared UTC instants from the database (`unix2datetime`) with `now()`, which is **local wall-clock** `DateTime` in Julia.

## Change

For running experiments (no `finished_at`), use `unix2datetime(time())` so the end time is the same kind of instant as `started_at`.

## Testing

`Pkg.test()` — all 126 tests passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-82a317e4-6f4f-4725-a752-58c36cc332ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-82a317e4-6f4f-4725-a752-58c36cc332ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

