### PR TITLE
Simplify statusline

### DIFF
--- a/src/dashboard/view.jl
+++ b/src/dashboard/view.jl
@@ -114,7 +114,6 @@ function _render_status_bar!(m::ProgressDashboard, area::Rect, buf)
     
     left = [
         Span(" $(SPINNER_BRAILLE[si]) ", tstyle(:accent)),
-        Span("Folder: ", tstyle(:text_dim)),
         Span(folder_label, tstyle(:primary)),
         Span("  $(DOT)  ", tstyle(:border)),
         Span("$(running_count) running", tstyle(:success)),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the redundant `Folder: ` label from the dashboard status bar. The watched path is still shown (shortened via `_format_status_folder_path`), immediately after the spinner, without the extra prefix described in the PR.

## Testing

- `julia --project=. -e 'using Pkg; Pkg.test()'` — all 126 tests passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dff40db0-3682-4677-a57c-d815077cdfa3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dff40db0-3682-4677-a57c-d815077cdfa3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

