### PR TITLE
Alignment of runs tab column names and entries

### DIFF
--- a/src/dashboard/runs_tab.jl
+++ b/src/dashboard/runs_tab.jl
@@ -34,12 +34,16 @@ function _view_runs_tab!(m::ProgressDashboard, area::Rect, buf::Buffer)
     show_date = !isempty(started_dates) && minimum(started_dates) < today_local
     time_col_width = show_date ? 16 : 10
 
+    # SelectableList renders row text at area.x + 2 (selection marker + gap); align headers.
+    list_text_offset = 2
+    ox = inner.x + list_text_offset
+
     # Column positions
-    col_time = inner.x
-    col_name = inner.x + time_col_width
-    col_status = inner.x + time_col_width + 25
-    col_progress = inner.x + time_col_width + 38
-    col_duration = inner.x + time_col_width + 55
+    col_time = ox
+    col_name = ox + time_col_width
+    col_status = ox + time_col_width + 25
+    col_progress = ox + time_col_width + 38
+    col_duration = ox + time_col_width + 55
 
     set_string!(buf, col_time, header_y, "Started", header_style)
     set_string!(buf, col_name, header_y, "Name", header_style)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes misalignment between the Runs tab column headers and row text.

**Cause:** `Tachikoma.SelectableList` renders each row’s text at `content.x + 2` (one cell for the selection marker, one for spacing). Headers were drawn starting at `inner.x`, so titles appeared two columns to the left of the values.

**Change:** Offset all header column positions by `+2` to match the list’s text origin.

## Testing

- `Pkg.test()` — all 126 tests passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ddcd19ed-2dfc-45a9-8b84-2dad18559009"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ddcd19ed-2dfc-45a9-8b84-2dad18559009"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

