### PR TITLE
Dynamic column spacing in run tab

### DIFF
--- a/src/dashboard/runs_tab.jl
+++ b/src/dashboard/runs_tab.jl
@@ -134,7 +134,9 @@ function _view_runs_tab!(m::ProgressDashboard, area::Rect, buf::Buffer)
     end
     name_w = min(max(min_name_w, max_name_len), max(1, name_w))
 
-    col_time = inner.x
+    # SelectableList draws row text at `text_area.x + 2` (marker column + space); align headers.
+    list_text_x = inner.x + 2
+    col_time = list_text_x
     col_name = col_time + time_col_width + 1
     col_status = col_name + name_w + 1
     col_progress = col_status + status_w + 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Runs tab used fixed column positions and truncated experiment names to 24 characters, leaving unused horizontal space on wide terminals.

## Changes

- **Layout**: Column widths are derived from the block’s inner width (`inner.width`). Status, Completed, and Duration get at least minimum widths and grow to fit sampled row content (first 64 experiments). **Name column width** is capped at the **longest experiment name** (minimum 4), not expanded to fill all spare space, so **extra horizontal room stays empty on the right** — columns stay **left-packed** with no gap between Name and Status on wide terminals.
- **Narrow terminals**: If there is not enough space, Duration → Progress → Status shrink in that order until the row fits.
- **Truncation**: `_truncate_display` truncates cell text to each column’s width using UTF-8–safe ellipsis (`...`), including for names (replacing byte-index `name[1:20]` slicing).
- **Header alignment**: Column titles use the same horizontal origin as list row text (`inner.x + 2`), matching `SelectableList`, which reserves two columns for the selection marker (`▸`) before drawing each row’s string.

## Testing

`Pkg.test()` — all tests passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5594deb8-420c-493a-a734-a8581d4d67d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5594deb8-420c-493a-a734-a8581d4d67d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

